### PR TITLE
Fix IllegalStateException when listFile(FileNameFilter)

### DIFF
--- a/superuser/src/main/java/com/topjohnwu/superuser/internal/ShellFile.java
+++ b/superuser/src/main/java/com/topjohnwu/superuser/internal/ShellFile.java
@@ -293,8 +293,10 @@ public class ShellFile extends File {
         String name;
         for (ListIterator<String> it = out.listIterator(); it.hasNext();) {
             name = it.next();
-            if (filter != null && !filter.accept(this, name))
+            if (filter != null && !filter.accept(this, name)) {
                 it.remove();
+                continue;
+            }
             if (defFilter.accept(this, name))
                 it.remove();
         }

--- a/superuser/src/main/java/com/topjohnwu/superuser/internal/ShellFile.java
+++ b/superuser/src/main/java/com/topjohnwu/superuser/internal/ShellFile.java
@@ -300,7 +300,7 @@ public class ShellFile extends File {
             if (defFilter.accept(this, name))
                 it.remove();
         }
-        return out.toArray(new String[0]);
+        return out.toArray(new String[out.size()]);
     }
 
     @Override


### PR DESCRIPTION
If the user provide a filter which accept the same elements as defFilter (`.` or `..`), `iterator.remove()` will be called twice.
It will throw an `IllegalStateException` according [the Javadoc](https://docs.oracle.com/javase/7/docs/api/java/util/Iterator.html#remove()).

I also set the right size of the result array as we already have it, no need to create an empty array.