### PR TITLE
Fix SuFile#getParent() when no parent available

### DIFF
--- a/io/src/main/java/com/topjohnwu/superuser/io/SuFile.java
+++ b/io/src/main/java/com/topjohnwu/superuser/io/SuFile.java
@@ -217,7 +217,8 @@ public class SuFile extends File {
 
     @Override
     public SuFile getParentFile() {
-        return new SuFile(getParent());
+        String parent = getParent();
+        return parent == null ? null : new SuFile(parent);
     }
 
     private long statFS(String fmt) {


### PR DESCRIPTION
The library does not handle the case where no parent available.
You can test the fix using the usual recursive usage of File#getParent():
```java
File file = ...
while (file != null) {
    ...
    file = file.getParent();
}
```
Note that return `null` is part of the `File#getParentFile()` contract.