### PR TITLE
Fix typos in documentation

### DIFF
--- a/io/src/main/java/com/topjohnwu/superuser/internal/ShellInputStream.java
+++ b/io/src/main/java/com/topjohnwu/superuser/internal/ShellInputStream.java
@@ -27,7 +27,7 @@ import java.io.InputStream;
 /**
  * This class makes sure actual I/O is always done in size of chunks (buf.length) regardless
  * whatever happens, including when user requests mark/reset operations.
- * The reason is because non aligned I/O using shell is extremely inefficient.
+ * The reason is because unaligned I/O using shell is extremely inefficient.
  * Default chunk size is 4KB.
  */
 class ShellInputStream extends InputStream {

--- a/io/src/main/java/com/topjohnwu/superuser/io/SuFile.java
+++ b/io/src/main/java/com/topjohnwu/superuser/io/SuFile.java
@@ -41,7 +41,7 @@ import java.util.Locale;
  * All methods for this class will be backed by executing commands via the global root shell.
  * The {@code Shell} instance will be acquired via {@link Shell#getShell()}.
  * <p>
- * This class has the exact same behavior as a normal {@link File}, however non of the operations
+ * This class has the exact same behavior as a normal {@link File}, however none of the operations
  * are atomic. This is a limitation of using shells, be aware of it.
  * <p>
  * For full functionality, the environment require: {@code rm}, {@code rmdir}, {@code readlink},

--- a/service/src/main/java/com/topjohnwu/superuser/ipc/RootService.java
+++ b/service/src/main/java/com/topjohnwu/superuser/ipc/RootService.java
@@ -65,7 +65,7 @@ import java.util.concurrent.ExecutorService;
  * {@link Context#startService(Intent)} because root services are strictly bound only.
  * A root service process will be terminated in the following conditions:
  * <ul>
- *     <li>(For non daemon services) All clients had unbound or terminated</li>
+ *     <li>(For non-daemon services) All clients had unbound or terminated</li>
  *     <li>Client called {@link #stop(Intent)}</li>
  *     <li>Root service called {@link #stopSelf()}</li>
  *     <li>The source application is updated/deleted</li>


### PR DESCRIPTION
This fixes several more typos that I noticed while reading through the documentation.