### PR TITLE
feat: Improve shell escape string

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -14,5 +14,6 @@ android {
 dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
     api("androidx.annotation:annotation:1.1.0")
+    testImplementation("junit:junit:4.13.1")
     javadocDeps("androidx.annotation:annotation:1.1.0")
 }

--- a/core/src/main/java/com/topjohnwu/superuser/ShellUtils.java
+++ b/core/src/main/java/com/topjohnwu/superuser/ShellUtils.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Some handy utility methods that are used in {@code libsu}.
@@ -36,6 +38,9 @@ import java.util.List;
  * <strong>You have been warned!!</strong>
  */
 public final class ShellUtils {
+
+    /** The pattern of list of char to escape from shell file names. */
+    private static final Pattern BASH_ESCAPED_CHARS = Pattern.compile("[$`\"\\\\ ;&|]");
 
     private ShellUtils() {}
 
@@ -120,17 +125,8 @@ public final class ShellUtils {
      * @return the formatted string.
      */
     public static String escapedString(String s) {
-        StringBuilder sb = new StringBuilder();
-        sb.append('"');
-        int len = s.length();
-        for (int i = 0; i < len; ++i) {
-            char c = s.charAt(i);
-            if ("$`\"\\".indexOf(c) >= 0)
-                sb.append('\\');
-            sb.append(c);
-        }
-        sb.append('"');
-        return sb.toString();
+        Matcher matcher = BASH_ESCAPED_CHARS.matcher(s);
+        return "\"" + matcher.replaceAll("\\\\$0") + "\"";
     }
 
     /**

--- a/core/src/test/java/com/topjohnwu/superuser/ShellUtilsTest.java
+++ b/core/src/test/java/com/topjohnwu/superuser/ShellUtilsTest.java
@@ -1,0 +1,29 @@
+package com.topjohnwu.superuser;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ShellUtilsTest {
+
+    @Test
+    public void escapedString() {
+        // Check default use case
+        assertEquals("\"script.sh\"", ShellUtils.escapedString("script.sh"));
+        // Check empty string
+        assertEquals("\"\"", ShellUtils.escapedString(""));
+        // Check variable substitution
+        assertEquals("\"script\\${var}.sh\"", ShellUtils.escapedString("script${var}.sh"));
+        // Check command substitution
+        assertEquals("\"script\\`command\\`.sh\"", ShellUtils.escapedString("script`command`.sh"));
+        // Check double quote escape
+        assertEquals("\"script\\\".sh\"", ShellUtils.escapedString("script\".sh"));
+        assertEquals("\"script.sh\\\\\"", ShellUtils.escapedString("script.sh\\"));
+        // Check spaces
+        assertEquals("\"script\\ with\\ spaces.sh\"", ShellUtils.escapedString("script with spaces.sh"));
+        // Check command chain
+        assertEquals("\"script.sh\\;command\"", ShellUtils.escapedString("script.sh;command"));
+        assertEquals("\"script.sh\\&\\&command\"", ShellUtils.escapedString("script.sh&&command"));
+        assertEquals("\"script.sh\\|\\|command\"", ShellUtils.escapedString("script.sh||command"));
+    }
+}


### PR DESCRIPTION
Hello John,

As promised, I start looking around your new version 😊 
Here is a proposal to improve the `espaceString()` method.
Even if the lib is supposed to be used by the app code only, it's hard to be sure no user nor third party app won't find a way to input weird paths to use in `SuFile`. So I tried to harden the method.

- Add space, semicolon, ampersand and pipe escape
- Add unit tests to ensure expected behavior
- Use pre-compiled pattern and matchers instead of double char loops for performance

Regards
Bruce