### PR TITLE
feat: Add Windows support for build script

### DIFF
--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -1,6 +1,7 @@
+import org.gradle.internal.os.OperatingSystem
 import java.io.OutputStream
-import java.nio.file.Paths
 import java.nio.file.Files
+import java.nio.file.Paths
 
 plugins {
     id("com.android.library")
@@ -18,8 +19,9 @@ android {
 android.libraryVariants.all {
     val jarTask = tasks.register("create${name.capitalize()}MainJar") {
         doLast {
+            val d8Command = if (OperatingSystem.current().isWindows) "d8.bat" else "d8"
             val d8 = Paths.get(android.sdkDirectory.path,
-                "build-tools", android.buildToolsVersion, "d8")
+                "build-tools", android.buildToolsVersion, d8Command)
             val classFile = Paths.get(buildDir.path, "intermediates",
                 "javac", this@all.name, "classes",
                 "com", "topjohnwu", "superuser", "internal", "IPCMain.class")


### PR DESCRIPTION
Hello again,

As discussed in #58 I am developing on Windows (no shame, I feel fine 😅 )
If you plan to support Windows, here is a patch to allow the build to work.

The issue comes from the `d8` call. Windows does not handle it properly.
Either you call `cmd d8` or `d8.bat` but `d8` only will not be found.

You can close it if Windows is not your target. I won't be offended.
(at least, it could help other when searching in issue to get the project built on Windows 😉 )

Regards,
Bruce