### PR TITLE
Use escaped file paths when opening fifo streams

### DIFF
--- a/io/src/main/java/com/topjohnwu/superuser/internal/FifoInputStream.java
+++ b/io/src/main/java/com/topjohnwu/superuser/internal/FifoInputStream.java
@@ -23,6 +23,7 @@ import android.system.Os;
 import androidx.annotation.RequiresApi;
 
 import com.topjohnwu.superuser.Shell;
+import com.topjohnwu.superuser.ShellUtils;
 import com.topjohnwu.superuser.io.SuFile;
 
 import java.io.File;
@@ -73,7 +74,9 @@ class FifoInputStream extends BaseSuInputStream {
     private void openStream(SuFile file) throws FileNotFoundException {
         try {
             Shell.getShell().execTask((in, out, err) -> {
-                String cmd = "cat " + file + " > " + fifo + " 2>/dev/null &\n";
+                String filePath = ShellUtils.escapedString(file.getPath());
+                String fifoPath = ShellUtils.escapedString(fifo.getPath());
+                String cmd = "cat " + filePath + " > " + fifoPath + " 2>/dev/null &\n";
                 Utils.log(TAG, cmd);
                 in.write(cmd.getBytes(UTF_8));
                 in.flush();

--- a/io/src/main/java/com/topjohnwu/superuser/internal/FifoOutputStream.java
+++ b/io/src/main/java/com/topjohnwu/superuser/internal/FifoOutputStream.java
@@ -23,6 +23,7 @@ import android.system.Os;
 import androidx.annotation.RequiresApi;
 
 import com.topjohnwu.superuser.Shell;
+import com.topjohnwu.superuser.ShellUtils;
 import com.topjohnwu.superuser.io.SuFile;
 
 import java.io.File;
@@ -75,7 +76,9 @@ class FifoOutputStream extends BaseSuOutputStream {
     private void openStream(SuFile file) throws FileNotFoundException {
         try {
             Shell.getShell().execTask((in, out, err) -> {
-                String cmd = "cat " + fifo + op() + file + " 2>/dev/null &\n";
+                String filePath = ShellUtils.escapedString(file.getPath());
+                String fifoPath = ShellUtils.escapedString(fifo.getPath());
+                String cmd = "cat " + fifoPath + op() + filePath + " 2>/dev/null &\n";
                 Utils.log(TAG, cmd);
                 in.write(cmd.getBytes(UTF_8));
                 in.flush();


### PR DESCRIPTION
The cat command used in `FifoInputStream.openStream()` & `FifoOutputStream.openStream()` is using unescaped file/fifo path strings. The method will fail if for eg. the path contains whitespaces.

Issue fixed by escaping the path strings using the already available method `ShellUtils.escapedString()`.