### PR TITLE
Better escapedString shell quoting method

### DIFF
--- a/core/src/main/java/com/topjohnwu/superuser/ShellUtils.java
+++ b/core/src/main/java/com/topjohnwu/superuser/ShellUtils.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern
 
 /**
  * Some handy utility methods that are used in {@code libsu}.
@@ -37,6 +38,8 @@ import java.util.List;
  */
 public final class ShellUtils {
 
+    private static final Pattern SHELL_UNSAFE = Pattern.compile("[^\\w@%+=:,./-]");
+    
     private ShellUtils() {}
 
     /**
@@ -120,17 +123,13 @@ public final class ShellUtils {
      * @return the formatted string.
      */
     public static String escapedString(String s) {
-        StringBuilder sb = new StringBuilder();
-        sb.append('"');
-        int len = s.length();
-        for (int i = 0; i < len; ++i) {
-            char c = s.charAt(i);
-            if ("$`\"\\".indexOf(c) >= 0)
-                sb.append('\\');
-            sb.append(c);
+        if (s.isEmpty()) {
+            return "''";
         }
-        sb.append('"');
-        return sb.toString();
+        if (!SHELL_UNSAFE.matcher(s).find()) {
+            return s;
+        }
+        return "'" + s.replace("'",  "'\"'\"'") + "'";
     }
 
     /**


### PR DESCRIPTION
Hi,
I wanted to contribute a shell quoting function I use, ported from CPython's implementation of shlex.quote function:
https://github.com/python/cpython/blob/93dc1654dc3c925c062e19f0ef8587aa8961ef8a/Lib/shlex.py#L325-L334
It works by simply surrounding with single quotes any input which contains unsafe characters, and then escaping single quotes in the input.
Unsafe characters are defined using a simple whitelist of safe characters rather than blacklisting certain symbols.
Any input that contains only safe characters is returned without quotes (unchanged from the input).

I also have ported the tests (only for shlex.quote, not shlex.join or the roundtripping tests) from
https://github.com/python/cpython/blob/876ade1ae3a805b546a211fd7303253c10395569/Lib/test/test_shlex.py#L327-L340
also added a few of my own
```java
    private static final String SAFE_UNQUOTED =
            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@%_-+=:,./";

    private static final String UNSAFE = "\"`$\\!\u00e9\u00e0\u00df{}";

    @Test
    void shellQuoteSingleQuote() {
        assertEquals("''", shellQuote(""));
    }

    @Test
    void shellQuoteSafeUnquoted() {
        assertEquals(SAFE_UNQUOTED, shellQuote(SAFE_UNQUOTED));
    }

    @Test
    void shellQuoteSpaces() {
        assertEquals("'test file name'", shellQuote("test file name"));
        assertEquals("'test\nfile\nname'", shellQuote("test\nfile\nname"));
        assertEquals("'test\r\nfile\r\nname'", shellQuote("test\r\nfile\r\nname"));
        assertEquals("'test\t file \nname'", shellQuote("test\t file \nname"));
    }

    @Test
    void shellQuoteUnsafe1() {
        int len = UNSAFE.length();
        for (int i = 0; i < len; i++) {
            String raw = "test" + UNSAFE.charAt(i) + "name";
            assertEquals("'" + raw + "'", shellQuote(raw));
        }
    }

    @Test
    void shellQuoteUnsafe2() {
        int len = UNSAFE.length();
        for (int i = 0; i < len; i++) {
            char c = UNSAFE.charAt(i);
            String raw = "test" + c + "'name'";
            String expected = "'test" + c + "'\"'\"'name'\"'\"''";
            assertEquals(expected, shellQuote(raw));
        }
    }

    @Test
    void shellQuoteMalicious() {
        assertEquals("'hello'\"'\"'; rm -rf /'",
                shellQuote("hello'; rm -rf /"));
        assertEquals("'hello\"; rm -rf /'",
                shellQuote("hello\"; rm -rf /"));
    }
```

It seems to work pretty well for my use, but I haven't tested it against libsu's internal uses.
You are welcome to use this it if you want.

Thanks for your work on magisk and libsu