### PR TITLE
Fix stopService crash under executor contention

### DIFF
--- a/service/src/main/java/com/topjohnwu/superuser/internal/RootServiceManager.java
+++ b/service/src/main/java/com/topjohnwu/superuser/internal/RootServiceManager.java
@@ -307,7 +307,8 @@ public class RootServiceManager implements IBinder.DeathRecipient, Handler.Callb
         while (it.hasNext()) {
             Map.Entry<ServiceConnection, Pair<RemoteService, Executor>> e = it.next();
             if (e.getValue().first.equals(s)) {
-                e.getValue().second.execute(() -> e.getKey().onServiceDisconnected(name));
+                ServiceConnection connection = e.getKey();
+                e.getValue().second.execute(() -> connection.onServiceDisconnected(name));
                 it.remove();
             }
         }


### PR DESCRIPTION
Executors aren't guaranteed to run submitted jobs immediately. When the executor is busy (e.g. multiple start/stop jobs in a short span of time), the onServiceDisconnected job can be delayed. However, ArrayMap entries are only valid for the duration of the iteration, so the job crashes when it tries to get the entry's key (ServiceConnection):

```
FATAL EXCEPTION: pool-2-thread-1
java.lang.IllegalStateException: This container does not support retaining Map.Entry objects
	at android.util.MapCollections$MapIterator.getKey(MapCollections.java:113)
	at com.topjohnwu.superuser.internal.RootServiceManager.lambda$stopInternal$6(RootServiceManager.java:310)
	at com.topjohnwu.superuser.internal.RootServiceManager$$ExternalSyntheticLambda8.run(Unknown Source:4)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
	at java.lang.Thread.run(Thread.java:920)
```

Use a reference to the key instead of the entry to fix the crash.