### PR TITLE
Fix #103

### DIFF
--- a/core/src/main/java/com/topjohnwu/superuser/internal/BuilderImpl.java
+++ b/core/src/main/java/com/topjohnwu/superuser/internal/BuilderImpl.java
@@ -89,7 +89,8 @@ public final class BuilderImpl extends Shell.Builder {
         if (shell == null && !hasFlags(FLAG_NON_ROOT_SHELL)) {
             try {
                 shell = build("su");
-                if (shell.getStatus() != ROOT_SHELL) {
+                if (shell.getStatus() != ROOT_SHELL &&
+                        shell.getStatus() != Shell.ROOT_MOUNT_MASTER) {
                     shell = null;
                     synchronized (Utils.class) {
                         Utils.confirmedRootState = false;

--- a/core/src/main/java/com/topjohnwu/superuser/internal/BuilderImpl.java
+++ b/core/src/main/java/com/topjohnwu/superuser/internal/BuilderImpl.java
@@ -89,8 +89,7 @@ public final class BuilderImpl extends Shell.Builder {
         if (shell == null && !hasFlags(FLAG_NON_ROOT_SHELL)) {
             try {
                 shell = build("su");
-                if (shell.getStatus() != ROOT_SHELL &&
-                        shell.getStatus() != Shell.ROOT_MOUNT_MASTER) {
+                if (shell.getStatus() < ROOT_SHELL) {
                     shell = null;
                     synchronized (Utils.class) {
                         Utils.confirmedRootState = false;


### PR DESCRIPTION
Status `ROOT_MOUNT_MASTER` can be achieved by setting use global mount namespace in Magisk Manager.