### PR TITLE
Fix unstable API behavior

### DIFF
--- a/core/src/main/java/com/topjohnwu/superuser/Shell.java
+++ b/core/src/main/java/com/topjohnwu/superuser/Shell.java
@@ -189,7 +189,8 @@ public abstract class Shell implements Closeable {
      * construct a new {@code Shell} in a background thread.
      * The cached/created shell instance is returned to the callback executed by provided executor.
      * @param executor the executor used to handle the result callback event.
-     *                 If {@code null} is passed, the callback can run on any thread.
+     *                 If {@code null} is passed, the callback will run on the same background
+     *                 thread as the new {@code Shell} is constructed.
      * @param callback invoked when a shell is acquired.
      */
     public static void getShell(@Nullable Executor executor, @NonNull GetShellCallback callback) {

--- a/core/src/main/java/com/topjohnwu/superuser/internal/MainShell.java
+++ b/core/src/main/java/com/topjohnwu/superuser/internal/MainShell.java
@@ -55,7 +55,7 @@ public final class MainShell {
 
     private static void returnShell(Shell s, Executor e, GetShellCallback cb) {
         if (e == null)
-            cb.onShell(s);
+            EXECUTOR.execute(() -> cb.onShell(s));
         else
             e.execute(() -> cb.onShell(s));
     }


### PR DESCRIPTION
topjohnwu/Magisk#5778

When `executor` is null, if `getShell()` is executed twice, the `callback` will be executed in different threads, which is bad. 
Since a major version to be released, this should be fixed to get stable behavior.
