### PR TITLE
Updated androidx.annotation:annotation to 1.4.0

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -13,6 +13,6 @@ android {
 
 dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
-    api("androidx.annotation:annotation:1.3.0")
-    javadocDeps("androidx.annotation:annotation:1.3.0")
+    api("androidx.annotation:annotation:1.4.0")
+    javadocDeps("androidx.annotation:annotation:1.4.0")
 }

--- a/nio/build.gradle.kts
+++ b/nio/build.gradle.kts
@@ -13,5 +13,5 @@ android {
 
 dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
-    api("androidx.annotation:annotation:1.3.0")
+    api("androidx.annotation:annotation:1.4.0")
 }


### PR DESCRIPTION
I recently had an issue with this library (which as of today uses androidx.annotation:annotation:1.3.0). My software would not compile unless libsu updated to 1.4.0 (there were other google libraries involved).

A local fix (which I applied successfully) is the following:

```gradle
implementation("com.github.topjohnwu.libsu:core:5.0.2") {
    exclude group: 'androidx.annotation', module: 'annotation'
}
implementation "androidx.annotation:annotation:1.4.0"
```

This PR updates the version inside the library. 
I built the project and it works fine with both `1.3.0` and `1.4.0`.