### PR TITLE
Do not readlink `/proc/self/exe`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,7 +96,7 @@ subprojects {
     afterEvaluate {
         android {
             compileSdkVersion(33)
-            buildToolsVersion = "32.0.0"
+            buildToolsVersion = "33.0.1"
 
             defaultConfig {
                 if (minSdkVersion == null)

--- a/core/src/main/java/com/topjohnwu/superuser/internal/Utils.java
+++ b/core/src/main/java/com/topjohnwu/superuser/internal/Utils.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -179,5 +180,25 @@ public final class Utils {
 
     public static boolean isMainShellRoot() {
         return MainShell.get().isRoot();
+    }
+
+    @SuppressLint("DiscouragedPrivateApi")
+    public static boolean isProcess64Bit() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            return Process.is64Bit();
+        }
+        try {
+            Class<?> classVMRuntime = Class.forName("dalvik.system.VMRuntime");
+            Method getRuntime = classVMRuntime.getDeclaredMethod("getRuntime");
+            getRuntime.setAccessible(true);
+            Object runtime = getRuntime.invoke(null);
+            Method is64Bit = classVMRuntime.getDeclaredMethod("is64Bit");
+            is64Bit.setAccessible(true);
+            // noinspection ConstantConditions
+            return (boolean) is64Bit.invoke(runtime);
+        } catch (ReflectiveOperationException e) {
+            err(e);
+            return false;
+        }
     }
 }

--- a/core/src/main/java/com/topjohnwu/superuser/internal/Utils.java
+++ b/core/src/main/java/com/topjohnwu/superuser/internal/Utils.java
@@ -187,6 +187,9 @@ public final class Utils {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             return Process.is64Bit();
         }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            return false;
+        }
         try {
             Class<?> classVMRuntime = Class.forName("dalvik.system.VMRuntime");
             Method getRuntime = classVMRuntime.getDeclaredMethod("getRuntime");

--- a/service/src/main/java/com/topjohnwu/superuser/internal/RootServiceManager.java
+++ b/service/src/main/java/com/topjohnwu/superuser/internal/RootServiceManager.java
@@ -216,7 +216,10 @@ public class RootServiceManager implements Handler.Callback {
             }
 
             // We cannot readlink /proc/self/exe on old kernels
-            String app_process = "/system/bin/app_process" + (Utils.isProcess64Bit() ? "64" : "32");
+            String app_process = "/system/bin/app_process";
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                app_process += Utils.isProcess64Bit() ? "64" : "32";
+            }
             String cmd = String.format(Locale.ROOT,
                     "(%s CLASSPATH=%s %s %s /system/bin %s " +
                     "com.topjohnwu.superuser.internal.RootServerMain '%s' %d %s >/dev/null 2>&1)&",

--- a/service/src/main/java/com/topjohnwu/superuser/internal/RootServiceManager.java
+++ b/service/src/main/java/com/topjohnwu/superuser/internal/RootServiceManager.java
@@ -215,7 +215,8 @@ public class RootServiceManager implements Handler.Callback {
                     break;
             }
 
-            String app_process = new File("/proc/self/exe").getCanonicalPath();
+            // We cannot readlink /proc/self/exe on old kernels
+            String app_process = "/system/bin/app_process" + (Utils.isProcess64Bit() ? "64" : "32");
             String cmd = String.format(Locale.ROOT,
                     "(%s CLASSPATH=%s %s %s /system/bin %s " +
                     "com.topjohnwu.superuser.internal.RootServerMain '%s' %d %s >/dev/null 2>&1)&",


### PR DESCRIPTION
Old platforms prevent `readlink /proc/self/exe` from being called from non-main threads on release builds, so hardcode `/system/bin/app_process` instead.

https://stackoverflow.com/questions/28590831/android-permission-denied-when-reading-proc-self-exe-from-non-main-thread

Fix canyie/Magisk#5. 
Fix topjohnwu/Magisk#6257